### PR TITLE
Add basic test for calciumcorrection

### DIFF
--- a/calciumcorrection.R
+++ b/calciumcorrection.R
@@ -1,0 +1,26 @@
+calciumcorrection=function(rawtrace){
+background=rawtrace[,grepl("BG",names(rawtrace))]
+background$average=(background$BG_1+background$BG_2+background$BG_3)/3
+bgcorrectedtraces=rawtrace[,grepl("Cell",names(rawtrace))]-background$average
+normalizationvalues=vector(length = ncol(bgcorrectedtraces))
+for (i in 1:ncol(bgcorrectedtraces)){
+  normalizationvalues[i]=mean(bgcorrectedtraces[,i])
+}
+normalizedtraces=data.frame(matrix(ncol = ncol(bgcorrectedtraces), nrow = nrow(bgcorrectedtraces)))
+for (i in 1:ncol(bgcorrectedtraces)){
+  normalizedtraces[,i]=bgcorrectedtraces[,i]/normalizationvalues[i]
+}
+colnames(normalizedtraces)=colnames(bgcorrectedtraces)
+loessmatrix=data.frame(matrix(NA, nrow = nrow(bgcorrectedtraces), ncol = ncol(bgcorrectedtraces)-1))
+Time=(1:nrow(bgcorrectedtraces))
+for (i in 1:ncol(bgcorrectedtraces))
+{
+  Testintermediate=as.matrix(bgcorrectedtraces[,i])
+  loessintermediate=loess(Testintermediate ~ Time, span = 0.45)
+  smoothed=predict(loessintermediate)
+  loessmatrix[,i]=smoothed-2
+}
+correctedmatrix=bgcorrectedtraces[,1:ncol(bgcorrectedtraces)]-loessmatrix
+correctedmatrix$Time=Time
+return(correctedmatrix)
+}

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+source('calciumcorrection.R')
+
+test_dir('tests/testthat')

--- a/tests/testthat/test-calciumcorrection.R
+++ b/tests/testthat/test-calciumcorrection.R
@@ -1,0 +1,18 @@
+source(file.path('..','..','calciumcorrection.R'))
+
+test_that('calciumcorrection returns expected structure', {
+  dummy <- data.frame(
+    Cell_1 = 1:10,
+    Cell_2 = seq(2,20,by=2),
+    BG_1   = rep(1,10),
+    BG_2   = rep(2,10),
+    BG_3   = rep(3,10)
+  )
+
+  result <- suppressWarnings(calciumcorrection(dummy))
+
+  expect_true(is.data.frame(result))
+  expect_equal(nrow(result), nrow(dummy))
+  expect_equal(ncol(result), 3)
+  expect_true('Time' %in% names(result))
+})


### PR DESCRIPTION
## Summary
- add standalone `calciumcorrection` function for testing
- create testthat runner
- test `calciumcorrection` on a dummy data frame

## Testing
- `R --vanilla -q -f tests/testthat.R`

------
https://chatgpt.com/codex/tasks/task_e_683feab165348326814f887d9b6ea223