### PR TITLE
Fix header typos

### DIFF
--- a/Calcium_Analysis-New.R
+++ b/Calcium_Analysis-New.R
@@ -5,8 +5,8 @@
 #       1. Segment your cells in FIJI, and use the multimeasure function in FIJI to obtain   #
 #       raw calcium traces.                                                                  #
 #       2. Make sure to include 3 background spots from spatially nonoverlapping locations   #
-#       3. Write the data into an excel file, with the trace coloumns named Cell_ and        #
-#          background coloumns as BG_                                                        #
+#       3. Write the data into an excel file, with the trace columns named Cell_ and        #
+#          background columns as BG_                                                        #
 ##############################################################################################
 #
 #


### PR DESCRIPTION
## Summary
- correct misspelled 'coloumns' in Calcium_Analysis-New.R

## Testing
- `Rscript -e 'library(testthat); source("calciumcorrection.R"); test_dir("tests/testthat")'` *(fails: there is no package called 'testthat')*


------
https://chatgpt.com/codex/tasks/task_e_683feaa42ae883268a4616a5678ad88d