### PR TITLE
Fix baseline correction matrix dimension

### DIFF
--- a/Calcium_Analysis-New.R
+++ b/Calcium_Analysis-New.R
@@ -32,7 +32,8 @@ colnames(normalizedtraces)=colnames(bgcorrectedtraces)
 # Baseline Drift corrected Traces using a loess regression
 
 
-loessmatrix=data.frame(matrix(NA, nrow = nrow(bgcorrectedtraces), ncol = ncol(bgcorrectedtraces)-1))
+# Ensure the baseline correction matrix matches the number of trace columns
+loessmatrix=data.frame(matrix(NA, nrow = nrow(bgcorrectedtraces), ncol = ncol(bgcorrectedtraces)))
 #loessmatrix=data.frame(matrix(NA, nrow = nrow(normalizedtraces), ncol = ncol(normalizedtraces)-1))
 Time=(1:nrow(bgcorrectedtraces))
 for (i in 1:ncol(bgcorrectedtraces))


### PR DESCRIPTION
## Summary
- ensure `loessmatrix` uses the correct number of columns

## Testing
- `R` was not installed, so script execution was not tested

------
https://chatgpt.com/codex/tasks/task_e_683fea3397ac8326be831196df960fa9