### PR TITLE
Refactor into R package

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,7 @@
+^\.github$
+^data/
+^tests/
+^python-env.yml
+^Calcium_Analysis-New\.R
+^modern_pipeline\.R
+^calciumcorrection\.R

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,14 @@
+name: R-CMD-check
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: r-lib/actions/setup-r@v2
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y r-cran-testthat
+      - name: Install package
+        run: R CMD INSTALL .
+      - name: Run tests
+        run: R -q -e 'testthat::test_dir("tests/testthat")'

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,0 +1,20 @@
+Package: CaImagingAnalysisFr
+Type: Package
+Title: Calcium Imaging Analysis Tools
+Version: 0.1.0
+Authors@R: c(person(given = "Calcium", family = "Team", role = c("aut", "cre"), email = "team@example.com"))
+Description: Utilities for calcium imaging analysis including baseline correction, spike inference and interactive exploration.
+License: MIT
+Encoding: UTF-8
+LazyData: true
+Depends: R (>= 3.5)
+Imports:
+    ggplot2,
+    reticulate
+Suggests:
+    shiny,
+    plotly,
+    targets,
+    testthat
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.3.1

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,0 +1,8 @@
+export(generate_synthetic_data)
+export(calcium_correction)
+export(infer_spikes)
+export(infer_spikes_advanced)
+export(plot_cell_trace)
+export(launch_interactive_viewer)
+export(calcium_pipeline)
+export(calciumcorrection)

--- a/R/calcium_correction.R
+++ b/R/calcium_correction.R
@@ -1,0 +1,22 @@
+#' Background and baseline correction
+#'
+#' @param raw_df Data frame with Cell_* and BG_* columns
+#' @param span Smoothing span for baseline estimation
+#' @return Data frame with corrected traces and Time column
+#' @export
+calcium_correction <- function(raw_df, span = 0.45) {
+  bg <- raw_df[, grepl("^BG_", names(raw_df))]
+  bg_avg <- rowMeans(bg)
+
+  cells <- raw_df[, grepl("^Cell_", names(raw_df))]
+  corrected <- cells - bg_avg
+
+  time <- seq_len(nrow(corrected))
+  baseline <- apply(corrected, 2, function(x) {
+    stats::predict(stats::loess(x ~ time, span = span))
+  })
+
+  norm <- corrected - baseline
+  norm$Time <- time
+  norm
+}

--- a/R/generate_synthetic_data.R
+++ b/R/generate_synthetic_data.R
@@ -1,0 +1,32 @@
+#' Generate synthetic calcium imaging dataset
+#'
+#' @param n_cells Number of cells to simulate
+#' @param n_time Number of time points
+#' @param spike_prob Probability of a spike at any frame
+#' @return Data frame with cell and background traces
+#' @examples
+#' df <- generate_synthetic_data(3, 500)
+#' head(df)
+#' @export
+generate_synthetic_data <- function(n_cells = 5, n_time = 1000, spike_prob = 0.02) {
+  set.seed(1)
+  bg <- replicate(3, cumsum(rnorm(n_time, sd = 0.001)) + rnorm(n_time, sd = 0.02))
+  bg <- as.data.frame(bg)
+  names(bg) <- paste0("BG_", seq_len(ncol(bg)))
+
+  cells <- replicate(n_cells, {
+    trace <- cumsum(rnorm(n_time, sd = 0.001)) + rnorm(n_time, sd = 0.05)
+    spikes <- rbinom(n_time, 1, spike_prob) == 1
+    for (t in which(spikes)) {
+      amp <- runif(1, 0.5, 2)
+      decay <- amp * exp(-seq_len(50) / 10)
+      end <- min(n_time, t + length(decay) - 1)
+      trace[t:end] <- trace[t:end] + decay[seq_len(end - t + 1)]
+    }
+    trace
+  })
+  cells <- as.data.frame(cells)
+  names(cells) <- paste0("Cell_", seq_len(ncol(cells)))
+
+  cbind(cells, bg)
+}

--- a/R/infer_spikes.R
+++ b/R/infer_spikes.R
@@ -1,0 +1,24 @@
+#' Spike inference via OASIS
+#'
+#' This uses the Python package `oasis` to deconvolve calcium traces. If the
+#' package is missing, it attempts installation and returns zeros on failure.
+#'
+#' @param trace Numeric vector of fluorescence values
+#' @return Data frame with deconvolved activity and estimated spikes
+#' @export
+infer_spikes <- function(trace) {
+  if (!reticulate::py_module_available("oasis")) {
+    tryCatch({
+      reticulate::py_install("oasis")
+    }, error = function(e) {
+      warning("oasis package not available; spikes will be zero")
+      return(data.frame(fit = rep(0, length(trace)), spike = rep(0, length(trace))))
+    })
+  }
+  if (!reticulate::py_module_available("oasis")) {
+    return(data.frame(fit = rep(0, length(trace)), spike = rep(0, length(trace))))
+  }
+  oasis <- reticulate::import("oasis.functions")
+  result <- oasis$deconvolve(trace)
+  data.frame(fit = result[[1]], spike = result[[2]])
+}

--- a/R/infer_spikes_advanced.R
+++ b/R/infer_spikes_advanced.R
@@ -1,0 +1,42 @@
+#' Spike inference with multiple backends
+#'
+#' Provides access to additional algorithms such as CaImAn and Suite2p
+#' via `reticulate`.
+#'
+#' @param trace Numeric vector of fluorescence values
+#' @param method One of "oasis", "caiman", or "suite2p"
+#' @return Data frame with deconvolved activity and estimated spikes
+#' @export
+infer_spikes_advanced <- function(trace, method = c("oasis", "caiman", "suite2p")) {
+  method <- match.arg(method)
+  if (method == "oasis") {
+    return(infer_spikes(trace))
+  }
+
+  if (method == "caiman") {
+    if (!reticulate::py_module_available("caiman")) {
+      tryCatch(reticulate::py_install("caiman"), error = function(e) NULL)
+    }
+    if (!reticulate::py_module_available("caiman")) {
+      warning("caiman not available; falling back to oasis")
+      return(infer_spikes(trace))
+    }
+    cm <- reticulate::import("caiman")
+    # Simple wrapper using OASIS from CaImAn
+    res <- cm$deconvolution$cd_oasis(trace)
+    return(data.frame(fit = res[[1]], spike = res[[2]]))
+  }
+
+  if (method == "suite2p") {
+    if (!reticulate::py_module_available("suite2p")) {
+      tryCatch(reticulate::py_install("suite2p"), error = function(e) NULL)
+    }
+    if (!reticulate::py_module_available("suite2p")) {
+      warning("suite2p not available; falling back to oasis")
+      return(infer_spikes(trace))
+    }
+    s2p <- reticulate::import("suite2p")
+    res <- s2p$deconv$deconvolve(trace)
+    return(data.frame(fit = res[["C_dec" ]], spike = res[["spks" ]]))
+  }
+}

--- a/R/interactive_app.R
+++ b/R/interactive_app.R
@@ -1,0 +1,26 @@
+#' Launch interactive viewer for calcium traces
+#'
+#' Provides a Shiny interface with adjustable parameters.
+#'
+#' @param raw_df Data frame containing raw traces
+#' @export
+launch_interactive_viewer <- function(raw_df) {
+  if (!requireNamespace("shiny", quietly = TRUE) ||
+      !requireNamespace("plotly", quietly = TRUE)) {
+    stop("Packages 'shiny' and 'plotly' are required for the interactive viewer")
+  }
+  cells <- names(raw_df)[grepl("^Cell_", names(raw_df))]
+  ui <- shiny::fluidPage(
+    shiny::sliderInput("span", "Loess span", min = 0.1, max = 1, value = 0.45, step = 0.05),
+    shiny::selectInput("cell", "Cell", choices = cells),
+    plotly::plotlyOutput("trace")
+  )
+  server <- function(input, output, session) {
+    corrected <- shiny::reactive(calcium_correction(raw_df, span = input$span))
+    output$trace <- plotly::renderPlotly({
+      df <- corrected()
+      plotly::ggplotly(plot_cell_trace(df, input$cell))
+    })
+  }
+  shiny::shinyApp(ui, server)
+}

--- a/R/legacy_calciumcorrection.R
+++ b/R/legacy_calciumcorrection.R
@@ -1,0 +1,33 @@
+#' Legacy correction function
+#'
+#' This function reproduces the behavior of the original script
+#' `calciumcorrection.R`. It is provided for backward compatibility.
+#'
+#' @param rawtrace Data frame of raw traces
+#' @return Data frame with corrected traces and Time column
+#' @export
+calciumcorrection <- function(rawtrace) {
+  background <- rawtrace[, grepl("BG", names(rawtrace))]
+  background$average <- (background$BG_1 + background$BG_2 + background$BG_3)/3
+  bgcorrectedtraces <- rawtrace[, grepl("Cell", names(rawtrace))] - background$average
+  normalizationvalues <- vector(length = ncol(bgcorrectedtraces))
+  for (i in seq_len(ncol(bgcorrectedtraces))) {
+    normalizationvalues[i] <- mean(bgcorrectedtraces[, i])
+  }
+  normalizedtraces <- data.frame(matrix(ncol = ncol(bgcorrectedtraces), nrow = nrow(bgcorrectedtraces)))
+  for (i in seq_len(ncol(bgcorrectedtraces))) {
+    normalizedtraces[, i] <- bgcorrectedtraces[, i] / normalizationvalues[i]
+  }
+  colnames(normalizedtraces) <- colnames(bgcorrectedtraces)
+  loessmatrix <- data.frame(matrix(NA, nrow = nrow(bgcorrectedtraces), ncol = ncol(bgcorrectedtraces)-1))
+  Time <- seq_len(nrow(bgcorrectedtraces))
+  for (i in seq_len(ncol(bgcorrectedtraces))) {
+    Testintermediate <- as.matrix(bgcorrectedtraces[, i])
+    loessintermediate <- loess(Testintermediate ~ Time, span = 0.45)
+    smoothed <- predict(loessintermediate)
+    loessmatrix[, i] <- smoothed - 2
+  }
+  correctedmatrix <- bgcorrectedtraces[, seq_len(ncol(bgcorrectedtraces))] - loessmatrix
+  correctedmatrix$Time <- Time
+  correctedmatrix
+}

--- a/R/pipeline_targets.R
+++ b/R/pipeline_targets.R
@@ -1,0 +1,16 @@
+#' Example `targets` pipeline
+#'
+#' This defines a simple workflow for generating synthetic data,
+#' performing correction and spike inference.
+#'
+#' @export
+calcium_pipeline <- function() {
+  if (!requireNamespace("targets", quietly = TRUE)) {
+    stop("Package 'targets' is required for the pipeline")
+  }
+  list(
+    targets::tar_target(raw, generate_synthetic_data()),
+    targets::tar_target(corrected, calcium_correction(raw)),
+    targets::tar_target(spikes, infer_spikes_advanced(corrected$Cell_1))
+  )
+}

--- a/R/plot_cell_trace.R
+++ b/R/plot_cell_trace.R
@@ -1,0 +1,20 @@
+#' Plot corrected trace with detected spikes
+#'
+#' @param corrected_df Output of [calcium_correction()]
+#' @param cell Name of a cell column
+#' @return ggplot object
+#' @export
+plot_cell_trace <- function(corrected_df, cell) {
+  dat <- data.frame(Time = corrected_df$Time,
+                    Signal = corrected_df[[cell]])
+  spikes <- infer_spikes(dat$Signal)
+  dat$Deconvolved <- spikes$fit
+  dat$Spike <- spikes$spike > 0
+
+  ggplot2::ggplot(dat, ggplot2::aes(Time, Signal)) +
+    ggplot2::geom_line(color = "steelblue") +
+    ggplot2::geom_line(ggplot2::aes(y = Deconvolved), color = "orange", alpha = 0.7) +
+    ggplot2::geom_point(data = dat[dat$Spike, ], ggplot2::aes(y = Signal), color = "red", size = 1) +
+    ggplot2::theme_minimal() +
+    ggplot2::labs(title = cell, y = "dF/F")
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# CaImagingAnalysisFr
+
+This package provides basic utilities for processing calcium imaging traces. Functions are organized as an R package for easier reuse and testing. Key features include:
+
+- Background correction and normalization
+- Spike inference via OASIS with optional CaImAn or Suite2p backends
+- Interactive visualization using Shiny and Plotly
+- Reproducible workflows using the `targets` package
+
+## Installation
+
+```
+# From the package root
+R CMD build .
+R CMD INSTALL CaImagingAnalysisFr_0.1.0.tar.gz
+```
+
+To manage R dependencies, you can initialize `renv`:
+
+```
+renv::init()
+```
+
+Python modules are accessed via `reticulate`. You can create a dedicated virtual environment:
+
+```
+reticulate::virtualenv_create('caimaging-env')
+reticulate::virtualenv_install('caimaging-env', c('oasis', 'caiman', 'suite2p'))
+```
+
+## Usage
+
+Generate synthetic data and view it interactively:
+
+```r
+library(CaImagingAnalysisFr)
+raw <- generate_synthetic_data(3, 500)
+launch_interactive_viewer(raw)
+```
+
+## Continuous Integration
+
+Tests in `tests/testthat` are executed automatically via GitHub Actions using the workflow found in `.github/workflows/test.yaml`.

--- a/python-env.yml
+++ b/python-env.yml
@@ -1,0 +1,8 @@
+name: caimaging-env
+dependencies:
+  - python=3.10
+  - pip
+  - pip:
+      - oasis
+      - caiman
+      - suite2p

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,5 +1,4 @@
 library(testthat)
-source('calciumcorrection.R')
-source("modern_pipeline.R")
+library(CaImagingAnalysisFr)
 
 test_dir('tests/testthat')

--- a/tests/testthat/test-calciumcorrection.R
+++ b/tests/testthat/test-calciumcorrection.R
@@ -1,5 +1,3 @@
-source(file.path('..','..','calciumcorrection.R'))
-
 test_that('calciumcorrection returns expected structure', {
   dummy <- data.frame(
     Cell_1 = 1:10,

--- a/tests/testthat/test-modern-pipeline.R
+++ b/tests/testthat/test-modern-pipeline.R
@@ -1,5 +1,3 @@
-source(file.path('..', '..', 'modern_pipeline.R'))
-
 context('Modern pipeline functions')
 
 test_that('Synthetic data generation returns expected format', {
@@ -9,7 +7,6 @@ test_that('Synthetic data generation returns expected format', {
   expect_true(all(grepl('BG_', names(df)[4:6])))
   expect_equal(nrow(df), 100)
 })
-
 
 test_that('calcium_correction returns normalized traces with Time', {
   df <- generate_synthetic_data(n_cells = 2, n_time = 50)


### PR DESCRIPTION
## Summary
- turn scripts into a lightweight R package
- include functions for interactive Shiny visualization and advanced spike inference
- add reproducible pipeline with `targets`
- document package usage and environment setup in README
- run tests in CI via GitHub Actions

## Testing
- `devtools::load_all(); testthat::test_dir("tests/testthat")`

------
https://chatgpt.com/codex/tasks/task_e_684103db9bb88326a7f5dc36bdfb2496